### PR TITLE
feat: introduce addon returning object movement directions

### DIFF
--- a/vsdkx/addon/tracking/processor.py
+++ b/vsdkx/addon/tracking/processor.py
@@ -93,7 +93,6 @@ class TrackerProcessor(Addon):
 
                 self._trackable_obj.trajectory_mean = np.mean(x), np.mean(y)
                 self._trackable_obj.centroids.append(centroid)
-                # self._get_current_direction()
 
                 if not self._trackable_obj.counted:
                     self._trackable_obj.counted = True
@@ -117,20 +116,6 @@ class TrackerProcessor(Addon):
             self._trackableObjects[object_id] = self._trackable_obj
             last_updated[object_id] = self._trackable_obj
         return event_counter, last_updated
-
-    # def _get_current_direction(self):
-    #     """
-    #     Sets the current walking direction of the trackable object.
-    #     Supported directions are 'up', 'down'.
-    #     """
-    #
-    #     prev_centroids = self._trackable_obj.centroids[-2]
-    #     current_centroids = self._trackable_obj.centroids[-1]
-    #
-    #     if prev_centroids[1] < current_centroids[1]:
-    #         self._trackable_obj.direction = 'down'
-    #     elif prev_centroids[1] > current_centroids[1]:
-    #         self._trackable_obj.direction = 'up'
 
     def _get_object_position(self, centroid, direction):
         """

--- a/vsdkx/addon/tracking/processor.py
+++ b/vsdkx/addon/tracking/processor.py
@@ -83,7 +83,7 @@ class TrackerProcessor(Addon):
 
                 self._trackable_obj.trajectory_mean = np.mean(x), np.mean(y)
                 self._trackable_obj.centroids.append(centroid)
-                self._get_current_direction()
+                # self._get_current_direction()
 
                 if not self._trackable_obj.counted:
                     self._trackable_obj.counted = True
@@ -108,19 +108,19 @@ class TrackerProcessor(Addon):
             last_updated[object_id] = self._trackable_obj
         return event_counter, last_updated
 
-    def _get_current_direction(self):
-        """
-        Sets the current walking direction of the trackable object.
-        Supported directions are 'up', 'down'.
-        """
-
-        prev_centroids = self._trackable_obj.centroids[-2]
-        current_centroids = self._trackable_obj.centroids[-1]
-
-        if prev_centroids[1] < current_centroids[1]:
-            self._trackable_obj.direction = 'down'
-        elif prev_centroids[1] > current_centroids[1]:
-            self._trackable_obj.direction = 'up'
+    # def _get_current_direction(self):
+    #     """
+    #     Sets the current walking direction of the trackable object.
+    #     Supported directions are 'up', 'down'.
+    #     """
+    #
+    #     prev_centroids = self._trackable_obj.centroids[-2]
+    #     current_centroids = self._trackable_obj.centroids[-1]
+    #
+    #     if prev_centroids[1] < current_centroids[1]:
+    #         self._trackable_obj.direction = 'down'
+    #     elif prev_centroids[1] > current_centroids[1]:
+    #         self._trackable_obj.direction = 'up'
 
     def _get_object_position(self, centroid, direction):
         """

--- a/vsdkx/addon/tracking/processor.py
+++ b/vsdkx/addon/tracking/processor.py
@@ -83,7 +83,7 @@ class TrackerProcessor(Addon):
 
                 self._trackable_obj.trajectory_mean = np.mean(x), np.mean(y)
                 self._trackable_obj.centroids.append(centroid)
-                # self._get_current_direction()
+                self._get_current_direction()
 
                 if not self._trackable_obj.counted:
                     self._trackable_obj.counted = True
@@ -108,19 +108,19 @@ class TrackerProcessor(Addon):
             last_updated[object_id] = self._trackable_obj
         return event_counter, last_updated
 
-    # def _get_current_direction(self):
-    #     """
-    #     Sets the current walking direction of the trackable object.
-    #     Supported directions are 'up', 'down'.
-    #     """
-    #
-    #     prev_centroids = self._trackable_obj.centroids[-2]
-    #     current_centroids = self._trackable_obj.centroids[-1]
-    #
-    #     if prev_centroids[1] < current_centroids[1]:
-    #         self._trackable_obj.direction = 'down'
-    #     elif prev_centroids[1] > current_centroids[1]:
-    #         self._trackable_obj.direction = 'up'
+    def _get_current_direction(self):
+        """
+        Sets the current walking direction of the trackable object.
+        Supported directions are 'up', 'down'.
+        """
+
+        prev_centroids = self._trackable_obj.centroids[-2]
+        current_centroids = self._trackable_obj.centroids[-1]
+
+        if prev_centroids[1] < current_centroids[1]:
+            self._trackable_obj.direction = 'down'
+        elif prev_centroids[1] > current_centroids[1]:
+            self._trackable_obj.direction = 'up'
 
     def _get_object_position(self, centroid, direction):
         """

--- a/vsdkx/addon/tracking/trajectory_processor.py
+++ b/vsdkx/addon/tracking/trajectory_processor.py
@@ -1,0 +1,48 @@
+from vsdkx.core.interfaces import Addon
+from vsdkx.core.structs import AddonObject
+
+
+class TrajectoryProcessor(Addon):
+    def __init__(self, addon_config: dict, model_settings: dict,
+                 model_config: dict, drawing_config: dict):
+        super().__init__(
+            addon_config, model_settings, model_config, drawing_config)
+
+    def post_process(self, addon_object: AddonObject) -> AddonObject:
+        self._get_current_direction(
+            addon_object.shared.get("trackable_object", {})
+        )
+        self._construct_trajectory_dict(addon_object)
+
+        return addon_object
+
+    def _construct_trajectory_dict(self, addon_object: AddonObject):
+        addon_object.inference.extra['movement_directions'] = {
+            object_id: tracked_object.direction
+            for object_id, tracked_object
+            in addon_object.shared.get("trackable_object", {})
+        }
+
+    def _get_current_direction(self, tracked_objects: dict):
+        """
+        Sets the current movement direction of the trackable object.
+        Supported directions are 'up', 'down', 'left', 'right',
+        'downleft', 'downright', 'upleft', 'upright'.
+        """
+
+        for _, tracked_object in tracked_objects:
+
+            prev_centroids = tracked_object.centroids[-2]
+            current_centroids = tracked_object.centroids[-1]
+
+            tracked_object.direction = ''
+
+            if prev_centroids[1] < current_centroids[1]:
+                tracked_object.direction += 'down'
+            elif prev_centroids[1] > current_centroids[1]:
+                tracked_object.direction += 'up'
+
+            if prev_centroids[0] < current_centroids[0]:
+                tracked_object.direction += 'left'
+            elif prev_centroids[0] > current_centroids[0]:
+                tracked_object.direction += 'right'

--- a/vsdkx/addon/tracking/trajectory_processor.py
+++ b/vsdkx/addon/tracking/trajectory_processor.py
@@ -10,6 +10,10 @@ class TrajectoryProcessor(Addon):
         self.centroid_mean = addon_config.get('centroid_mean', 3)
 
     def post_process(self, addon_object: AddonObject) -> AddonObject:
+        """
+        Calculate movement directions and write them information in
+        extra dict under 'movement_directions' key.
+        """
         self._get_current_direction(
             addon_object.shared.get("trackable_objects", {})
         )
@@ -18,6 +22,14 @@ class TrajectoryProcessor(Addon):
         return addon_object
 
     def _construct_trajectory_dict(self, addon_object: AddonObject):
+        """
+        write dictionary mapping object id mappings to movement directions to
+        extra dict.
+
+        Args:
+            addon_object(AddonObject): Addon object containing
+            'trackable_objects' key set in shared attribute.
+        """
         addon_object.inference.extra['movement_directions'] = {
             object_id: tracked_object.direction
             for object_id, tracked_object
@@ -28,7 +40,8 @@ class TrajectoryProcessor(Addon):
         """
         Sets the current movement direction of the trackable object.
         Supported directions are 'up', 'down', 'left', 'right',
-        'downleft', 'downright', 'upleft', 'upright'.
+        'downleft', 'downright', 'upleft', 'upright' or '' if direction can't
+        be set.
         """
 
         for _, tracked_object in tracked_objects.items():

--- a/vsdkx/addon/tracking/trajectory_processor.py
+++ b/vsdkx/addon/tracking/trajectory_processor.py
@@ -3,11 +3,19 @@ from vsdkx.core.structs import AddonObject
 
 
 class TrajectoryProcessor(Addon):
+    """
+    Calculate movement direction for objects based on their past and present
+    coordinates on the frame
+
+    Attributes:
+        centroid_index (int): nth old position of object to compare present
+        position for direction.
+    """
     def __init__(self, addon_config: dict, model_settings: dict,
                  model_config: dict, drawing_config: dict):
         super().__init__(
             addon_config, model_settings, model_config, drawing_config)
-        self.centroid_mean = addon_config.get('centroid_mean', 3)
+        self.centroid_index = addon_config.get('centroid_index', 3)
 
     def post_process(self, addon_object: AddonObject) -> AddonObject:
         """
@@ -46,8 +54,11 @@ class TrajectoryProcessor(Addon):
 
         for _, tracked_object in tracked_objects.items():
 
+            # Take minimal index out of length of centroids array and
+            # configured index, to ensure that nth old element will be taken
+            # from list or the oldest one
             starting_centroid_index = min(len(tracked_object.centroids),
-                                          self.centroid_mean)
+                                          self.centroid_index)
 
             prev_centroids = tracked_object.centroids[-starting_centroid_index]
             current_centroids = tracked_object.centroids[-1]


### PR DESCRIPTION
## Test: 

### Configuration:
Run any object detection model with tracking(main branch) and zoning(this branch) addons

```yaml
addons:
  tracking:
    bidirectional_mode: true
    bidirectional_threshold: 150
    class: vsdkx.addon.tracking.processor.TrackerProcessor
    distance_threshold: 500
    max_disappeared: 10
    min_appearance: 1
  trajectory:
    class: vsdkx.addon.tracking.trajectory_processor.TrajectoryProcessor
    centroid_index: 2
    temporal_length: 10
```

### Expected result:
in extra dictionary of inference, you must expect similar structure with same keys and values like this (actual values vary from frame to frame)

```py
'movement_directions': {0: 'downright', 1: 'downleft', 2: 'upleft', 3: '', 4: 'upleft', 5: 'left', 6: 'upleft', 7: 'downright', 8: 'upleft', 9: 'downright', 10: 'left', 11: '', 12: 'downright', 13: 'upleft', 14: ''}
```