### PR TITLE
fix: updates bidirectional logic 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@ max_disappeared: 10, # Object disappearance threshold in frames
 distance_threshold: 540, # Maximum distance threshold between two objects
 bidirectional_mode: False, # Flag for turning on/off the bidirectional mode
 bidirectional_threshold: 150, # Threshold for bidirectional mode (required when bidirectional_mode is True)
-min_appearance: 40 # min number of appearence for an object to calculate mean of Y coord
 ```

--- a/vsdkx/addon/tracking/processor.py
+++ b/vsdkx/addon/tracking/processor.py
@@ -30,11 +30,11 @@ class TrackerProcessor(Addon):
         """
         Call tracking function with apropriate boxes and write resulting data
         in Addon Object
-        
+
         Args:
             addon_object (AddonObject): addon object containing information
             about frame and/or other addons shared data
-        
+
         Returns:
             (AddonObject): addon object has updated information for frame,
             inference, result and/or shared information:
@@ -54,7 +54,7 @@ class TrackerProcessor(Addon):
             boxes (np.ndarray): bounding boxes of objects
         Returns:
             event_counter (int | dict): Amount of newly tracked events,
-            returns an int on unidirectional mode and a dict on a 
+            returns an int on unidirectional mode and a dict on a
             bidirectional mode
             last_updated (dict): Filtered list of
             trackable objects that were updated on the last frame
@@ -100,18 +100,16 @@ class TrackerProcessor(Addon):
                     if not self._bidirectional_mode:
                         event_counter += 1
 
-                if self._bidirectional_mode and \
-                        not self._trackable_obj.position:
-                    if self._trackable_obj.tracked_number >= self._min_appearance:
-                        events_in, events_out = \
-                            self._get_object_position(centroid,
-                                                      direction_of_position)
-                        events_in_counter += events_in
-                        events_out_counter += events_out
-                        event_counter = {'in': events_in_counter,
-                                         'out': events_out_counter}
-                    else:
-                        self._trackable_obj.tracked_number += 1
+                if self._bidirectional_mode:
+                    events_in, events_out = \
+                        self._get_object_position(centroid,
+                                                  direction_of_position)
+                    events_in_counter += events_in
+                    events_out_counter += events_out
+                    event_counter = {'in': events_in_counter,
+                                     'out': events_out_counter}
+                else:
+                    self._trackable_obj.tracked_number += 1
             # store the trackable object in our dictionary
             self._trackable_obj.bounding_box = bounding_boxes[object_id]
             self._trackableObjects[object_id] = self._trackable_obj
@@ -143,8 +141,7 @@ class TrackerProcessor(Addon):
             centroid (tuple): Centroid tuple
             direction (float): Float indicating the object's direction
         """
-        event_counter_in = 0
-        event_counter_out = 0
+        event_counter = {'in': 0, 'out': 0}
 
         # Define the direction towards that a person is walking to & update
         # it on the obj instance
@@ -152,16 +149,14 @@ class TrackerProcessor(Addon):
         if direction >= 0 and \
                 centroid[1] > self._bidirectional_threshold:
             self._trackable_obj.position = 'in'
-            event_counter_in = + 1
-
         elif direction <= 0 and \
                 centroid[1] < self._bidirectional_threshold:
             self._trackable_obj.position = 'out'
-            event_counter_out = + 1
 
         # If the new direction of the object is different to its
         # previous direction update the people counter camera
         if self._trackable_obj.position != self._trackable_obj.prev_position:
             self._trackable_obj.prev_position = self._trackable_obj.position
+            event_counter[self._trackable_obj.position] = +1
 
-        return event_counter_in, event_counter_out
+        return event_counter['in'], event_counter['out']

--- a/vsdkx/addon/tracking/processor.py
+++ b/vsdkx/addon/tracking/processor.py
@@ -24,11 +24,10 @@ class TrackerProcessor(Addon):
             addon_config['distance_threshold'])
         self._bidirectional_mode = addon_config['bidirectional_mode']
         self._bidirectional_threshold = addon_config['bidirectional_threshold']
-        self._min_appearance = addon_config['min_appearance']
 
     def post_process(self, addon_object: AddonObject) -> AddonObject:
         """
-        Call tracking function with apropriate boxes and write resulting data
+        Call tracking function with appropriate boxes and write resulting data
         in Addon Object
 
         Args:

--- a/vsdkx/addon/tracking/settings.py
+++ b/vsdkx/addon/tracking/settings.py
@@ -2,6 +2,5 @@ DEFAULT = {
     "bidirectional_mode": True,
     "bidirectional_threshold": 150,
     "distance_threshold": 500,
-    "max_disappeared": 10,
-    "min_appearance": 1
+    "max_disappeared": 10
 }


### PR DESCRIPTION
## Description

This MR updates the logic of bidirectional object tracking to to get the new position of the object at every frame.

Previously the bidirectional position of an object would only update the first time we start tracking the object. If for instance the object would change its direction of movement, that change wouldn't have been tracked.  This resulted that when the direction of objects was not updated the following would be returned on the `inference.extra` object:

```{'tracked_objects':0, ...}```

The changes on the logic introduced on this MR allow to update a trackable object's movement changes at every frame, where the `inference.extra` object returns the delta of the people that have walked towards the `in` and `out` directions:

```
{'tracked_objects': {'in': 0, 'out': 0}, ...}
```

## How to test

Run people detection using the `people_walking.mp4` video as input by following the steps below: 

- Set the tracker add on to point into this branch via `requirements.txt`: 
```
git+https://github.com/natix-io/vsdkx-addon-tracking.git@nicole/tracker_bidirectional
```
- `pip install -r requirements.txt` to install all requirements in people detection
-  Enable the tracker to run on bidirectional mode in `vsdkx/settings.yaml`:
```
 tracking:
    bidirectional_mode: true
    bidirectional_threshold: 150
    class: vsdkx.addon.tracking.processor.TrackerProcessor
    distance_threshold: 100
    max_disappeared: 30
    min_appearance: 1
```
- `python vsdkx-run.py --no-server --video-path __assets/people_walking.mp4`

## What to expect

- The `inference.extra` object returns the `tracked_objects` in the following format 'tracked_objects': {'in': 0, 'out': 0}`. 
- When objects change direction, the delta of that change is accounted in the `tracked_objects` as expected