### PR TITLE
fix: returns updated trackable objects when no detections occur

### DIFF
--- a/vsdkx/addon/tracking/centroidtracker.py
+++ b/vsdkx/addon/tracking/centroidtracker.py
@@ -106,7 +106,7 @@ class CentroidTracker:
 
             # return early as there are no centroids or tracking info
             # to update
-            return self.objects, self.bounding_box
+            return self.objects, self.bounding_box, self.updated
 
         # initialize an array of input centroids for the current frame
         input_centroids = np.zeros((len(rects), 2), dtype="int")


### PR DESCRIPTION
Fix for returning the updated trackable objects dictionary when centroid update terminates early due to no bounding box detection.